### PR TITLE
Report CPU usage by core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,62 @@
-cmake_minimum_required(VERSION 2.6)
-project(NTop C)
+cmake_minimum_required(VERSION 3.8)
+
+project(NTop
+  LANGUAGES
+    C
+    CXX
+)
 
 option(ENABLE_UNICODE "Compile with Unicode support" OFF)
 
-if(ENABLE_UNICODE)
-	add_definitions(-DUNICODE -D_UNICODE)
-endif()
+add_executable(${PROJECT_NAME}
+  ntop.c
+  util.c
+  vi.c
+)
 
-add_executable(NTop ntop.c util.c vi.c)
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ENABLE_UNICODE}>:
+      UNICODE
+      _UNICODE
+    >
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PRIVATE
+    WindowsApp
+    wbemuuid
+)
+
+target_compile_features(${PROJECT_NAME}
+  PRIVATE cxx_std_17
+)
+
+# Temporary fix for C++/WinRT bug
+target_compile_options(${PROJECT_NAME}
+  PRIVATE /permissive
+)
+
+find_package(WIL CONFIG REQUIRED)
+
+add_executable(wmi
+  main.c
+  wmi.cpp
+)
+
+target_link_libraries(wmi
+  PRIVATE
+    WindowsApp
+    wbemuuid
+    WIL::WIL
+)
+
+target_compile_features(wmi
+  PRIVATE
+    cxx_std_17
+)
+
+# Temporary fix for C++/WinRT bug
+target_compile_options(wmi
+  PRIVATE /permissive
+)

--- a/main.c
+++ b/main.c
@@ -1,0 +1,23 @@
+#include "wmi.h"
+
+#include <stdio.h>
+
+#include <windows.h>
+#include <synchapi.h>
+
+int main()
+{
+        struct WMI* wmi = NewWMIService();
+
+        int* loads = NULL;
+        size_t count = 0;
+        for(int i = 0; i < 1000 ; ++i)
+        {
+            WMIQueryProcessorTime(wmi, &loads, &count);
+            for(size_t c = 0 ; c < count; ++c) printf("%d\n", loads[c]);
+            printf("\n"); fflush(NULL);
+            Sleep(500);
+        }
+
+        CloseWMIService(wmi);
+}

--- a/wmi.cpp
+++ b/wmi.cpp
@@ -1,0 +1,182 @@
+// Configuration defines
+#define _WIN32_DCOM
+#define WIL_ENABLE_EXCEPTIONS
+
+#include <wil/resource.h>
+
+#include <windows.h>
+
+// C++/WinRT includes
+#include <winrt/base.h>
+
+#include <WbemIdl.h>
+
+#include <iostream>
+#include <exception>
+
+struct WMI
+{
+    winrt::impl::com_ref<IWbemLocator> locator;
+    winrt::com_ptr<IWbemServices> services;
+
+    std::vector<int> loads;
+};
+
+extern "C"
+{
+    WMI* NewWMIService()
+    {
+        winrt::init_apartment();
+
+        WMI* wmi = new WMI{};
+
+        wmi->locator = winrt::create_instance<IWbemLocator>(CLSID_WbemLocator);
+        winrt::check_hresult(wmi->locator->ConnectServer(
+            wil::make_bstr(LR"(ROOT\CIMV2)").get(),
+            nullptr, nullptr,
+            0, 0, 0, 0,
+            wmi->services.put())
+        );
+
+        winrt::check_hresult(CoSetProxyBlanket(
+            wmi->services.get(),
+            RPC_C_AUTHN_WINNT,
+            RPC_C_AUTHZ_NONE,
+            nullptr,
+            RPC_C_AUTHN_LEVEL_CALL,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            nullptr,
+            EOAC_NONE)
+        );
+
+        wmi->loads.resize(std::thread::hardware_concurrency());
+
+        return wmi;
+    }
+
+    int WMIQueryProcessorTime(WMI* wmi, int** loads, size_t* count)
+    {
+        winrt::com_ptr<IEnumWbemClassObject> enumerator;
+        winrt::check_hresult(wmi->services->ExecQuery(
+            L"WQL",
+            L"SELECT PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name <> '_Total'",
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+            nullptr,
+            enumerator.put())
+        );
+
+        for (size_t i = 0 ; i < wmi->loads.size() ; ++i)
+        {
+            winrt::com_ptr<IWbemClassObject> class_object;
+            ULONG ret;
+            winrt::check_hresult(enumerator->Next(
+                WBEM_INFINITE,
+                1,
+                class_object.put(),
+                &ret)
+            );
+
+            if (ret == 0) { break; }
+
+            wil::unique_variant percent;
+            winrt::check_hresult(class_object->Get( L"PercentProcessorTime", 0, percent.addressof(), nullptr, nullptr));
+
+            wmi->loads.at(i) = std::stoi(percent.bstrVal);
+
+            *loads = wmi->loads.data();
+            *count = wmi->loads.size();
+        }
+
+        return 0;
+    }
+
+    void CloseWMIService(WMI* wmi)
+    {
+        delete wmi;
+    }
+}
+/*
+int main()
+{
+    try
+    {
+        winrt::init_apartment();
+
+        auto locator = winrt::create_instance<IWbemLocator>(CLSID_WbemLocator);
+        winrt::com_ptr<IWbemServices> services;
+        winrt::check_hresult(locator->ConnectServer(
+            wil::make_bstr(LR"(ROOT\CIMV2)").get(),
+            nullptr, nullptr,
+            0, 0, 0, 0,
+            services.put())
+        );
+
+        winrt::check_hresult(CoSetProxyBlanket(
+            services.get(),
+            RPC_C_AUTHN_WINNT,
+            RPC_C_AUTHZ_NONE,
+            nullptr,
+            RPC_C_AUTHN_LEVEL_CALL,
+            RPC_C_IMP_LEVEL_IMPERSONATE,
+            nullptr,
+            EOAC_NONE)
+        );
+
+        std::vector<int> loads(std::thread::hardware_concurrency());
+
+        for(int I = 0 ; I < 10 ; ++I)
+        {
+
+        auto refresher = winrt::create_instance<IWbemRefresher>(CLSID_WbemRefresher);
+        winrt::com_ptr<IWbemConfigureRefresher> config;
+        winrt::check_hresult(refresher->QueryInterface(config.put()));
+
+        winrt::com_ptr<IEnumWbemClassObject> enumerator;
+        winrt::check_hresult(services->ExecQuery(
+            L"WQL",
+            L"SELECT PercentProcessorTime FROM Win32_PerfFormattedData_PerfOS_Processor WHERE Name <> '_Total'",
+            WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY,
+            nullptr,
+            enumerator.put())
+        );
+
+        //while (enumerator)
+        for (size_t i = 0 ; i < loads.size() ; ++i)
+        {
+            winrt::com_ptr<IWbemClassObject> class_object;
+            ULONG ret;
+            winrt::check_hresult(enumerator->Next(
+                WBEM_INFINITE,
+                1,
+                class_object.put(),
+                &ret)
+            );
+
+            if (ret == 0) { break; }
+
+            wil::unique_variant percent;
+            winrt::check_hresult(class_object->Get( L"PercentProcessorTime", 0, percent.addressof(), nullptr, nullptr));
+
+            loads.at(i) = std::stoi(percent.bstrVal);
+        }
+
+        for(auto& load : loads) std::cout << load << "\n";
+        std::cout << std::endl;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds{500});
+        }
+    }
+    catch(winrt::hresult_error& err)
+    {
+        std::wcerr << err.message().c_str() << " (" << err.code() << ")" << std::endl;
+        std::exit(err.code());
+    }
+    catch(std::exception& err)
+    {
+        std::cerr << err.what() << std::endl;
+        std::exit(-1);
+    }
+
+    return 0;
+}
+*/

--- a/wmi.h
+++ b/wmi.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct WMI WMI;
+
+WMI* NewWMIService();
+
+int WMIQueryProcessorTime(WMI* wmi, int** loads, size_t* count);
+
+void CloseWMIService(WMI* wmi);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Because nobody seemed to get the ball rolling on this (and it would be mighty useful) I thought I'd get things going by doing part of the work, hoping others will pick up the other, seemingly more involved part: hooking the info up to UI. This draft PR addresses #9.

# If you would like to see this feature happen, please tune into development

Per-core CPU load reads on Windows AFAIK is only available through WMI, which is a C++ API. While WMI may be operable from COM alone, that's like flying an X-Wing blindfolded, which I don't intend to do. For the purpose of enabling per-core reading (and later GPU readings, which was [also requested](https://github.com/gsass1/NTop/issues/27)) this implementation adds a C++ translation unit exposing a C API.

Notes:
- The implementation uses the C++/WinRT wrapper for handling COM more tersely. There are no calls to the Windows Runtime. (Not that I'm aware of.) If someone really wants to unroll the COM wrappers, be my guest.
- The `/permissive` flag added to the C++ source file is a temporary workaround to a bug in C++/WinRT, generating non-strictly ISO C++ headers. This should be fixed in a future version of the Windows SDK.
- The implementation uses WIL for two tiny parts of the code, both can be easily removed if dependencies are a hassle
  - wrapper for the BSTR type
  - wrapper for the VARIANT type
- The prototype was a C++ application independent of NTop, I left it in comments for reference.
  - The C version (omitting error handling) is in `main.c`.
  - These parts should be removed in final versions, I just left them to show how to use the C API.
- Added generator expression in CMake for declarative `option` handling as opposed to imperative branching.

## Call to action

If someone is interested (either @gsass1 or anyone else) in hooking this information up to the UI, which too is a non-zero amount of work, help push it through the finish line. I did this part, because I saw that obtaining this info was non-trivial (to say the least) and if this was blocking people from making it happen: now it's done.