### PR TITLE
Fix package id according to Choco guidelines

### DIFF
--- a/ntop.nuspec
+++ b/ntop.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
-    <id>NTop.Portable</id>
+    <id>ntop.portable</id>
     <title>NTop</title>
     <version>0.3.2</version>
     <authors>Gian Sass</authors>


### PR DESCRIPTION
Hello, thanks for providing the package on Chocolatey!

I have noticed a small mistake that violates Chocolatey guidelines and was overlooked by a moderator.

Please see https://community.chocolatey.org/courses/creating-chocolatey-packages/naming-description-and-versioning

> There are some guidelines in terms of the package id (\<id\> tag in the nuspec):
> - **Use only lowercase letters**, even if you used uppercase letters in the package title. (This is considered a guideline because it is correctable in other ways). Once a package is submitted (even prior moderation), the Gallery will always show the id with the casing of the first package version. In addition, changing the casing of the package id may have negative side effects on dependencies (note: this last statement needs verified).

(Do not re-push the current version to Chocolatey with this small change, just any upcoming new releases.)