### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NTop as in Windows NT-op or NukeTop. Whatever you prefer (the latter obviously).
 
 ### Scoop
 
-With extras bucket: `scoop install ntop`
+`scoop install ntop`
 
 ## Usage
 


### PR DESCRIPTION
The package got moved to scoop's Main bucket. See
https://github.com/ScoopInstaller/Main/blob/master/bucket/ntop.json