### PR TITLE
Fix Unicode build

### DIFF
--- a/util.h
+++ b/util.h
@@ -33,4 +33,21 @@ void *xmalloc(size_t size);
 void *xrealloc(void *ptr, size_t size);
 void *xcalloc(size_t num, size_t size);
 
+#ifdef UNICODE
+	/*
+	 * Zero extension is correct for converting any legal ASCII char
+	 * to its corresponding UTF-16LE code unit
+	 */
+	#define TCharFromAscii(c) ((TCHAR)(unsigned char)c)
+#else
+	#define TCharFromAscii(c) (c)
+#endif
+
+/*
+ * Use these zero-extending functions to defend against stdlib undefined behavior
+ * specified by the is*-family of ctype functions
+ */
+#define IntFromTChar(t) ((int)(unsigned int)t)
+#define IntFromChar(c) ((int)(unsigned int)c)
+
 #endif


### PR DESCRIPTION
This patch makes a number of code changes to make Unicode build actually work (instead of crashing). This involves using the `_t`-family of CRT string routines and using the `_T()` macro to wrap char and string literals wherever Unicode needs to be handled.

Some macros are also added to util.h that perform explicit zero-extending operations on character types; this is to defend against build setups whose compiler (possibly through a command line switch) treats `char` and/or `wchar_t` as signed, therefore performs sign-extension when a `char` is implicitly converted to an `int` or a `wchar_t`.

Care has been taken to ensure Unicode build of the program doesn't do things differently from the ASCII/MBCS build; in particular config file operations remain ASCII-based as they are today.