### PR TITLE
feat: add process name filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ scoop install ntop
 | `-C` | Use monochrome color scheme. |
 | `-h` | Display help info. |
 | `-p` PID, PID... | Show only the given PIDs. |
+| `-n` NamePart, NamePart... | Show only processes containing at least one of the name parts. |
 | `-s` COLUMN | Sort by this column. |
 | `-u` USERNAME | Only display processes belonging to this user. |
 | `-v` | Print version. |

--- a/ntop.nuspec
+++ b/ntop.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ntop.portable</id>
     <title>NTop</title>
-    <version>0.3.2</version>
+    <version>0.3.3</version>
     <authors>Gian Sass</authors>
     <owners>Gian Sass</owners>
     <summary>htop-like system-monitor for Windows with Vi-keybindings</summary>


### PR DESCRIPTION
Added the commandline option -n to show only processes that names contain one of the case sensitive filter parts.
Usage:
     ntop -n NamePart[,NamePart[, ...]]
Example:
     ntop -n cmd,Code,chrom