### PR TITLE
Use GetNativeSystemInfo instead of GetSystemInfo

### DIFF
--- a/ntop.c
+++ b/ntop.c
@@ -885,7 +885,7 @@ static void PollInitialSystemInfo(void)
 	CPUFrequency = (double)PerformanceFrequency.QuadPart / 1000000.0;
 
 	SYSTEM_INFO SystemInfo;
-	GetSystemInfo(&SystemInfo);
+	GetNativeSystemInfo(&SystemInfo);
 	CPUCoreCount = SystemInfo.dwNumberOfProcessors;
 
 	HKEY Key;


### PR DESCRIPTION
Based on [Microsoft documentation](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo) we need to use [GetNativeSystemInfo ](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getnativesysteminfo)instead of GetSystemInfo to get correct data for WOW64.

fix #67 